### PR TITLE
Add a way to renew DHCP lease from the command line.

### DIFF
--- a/fish/myfunctions/renew.fish
+++ b/fish/myfunctions/renew.fish
@@ -1,0 +1,8 @@
+
+function renew -d "renew dhcp lease from the command line"
+    if type -q ipconfig
+        sudo ipconfig set en0 DHCP
+    else
+        echo "ipconfig required"
+    end
+end


### PR DESCRIPTION
Why: Need a good way to easily renew the lease -- this is a workaround
for router and network card problems that I've been having.

How: Adding a new fish function.

Tags: fish, dhcp, networking