### PR TITLE
Update git config to only allow fast forward pulls.

### DIFF
--- a/git/config
+++ b/git/config
@@ -29,6 +29,9 @@
   # to support the rebase-style workflow : ) 
   ff = only
 
+[pull]
+  ff = only
+
 [push]
   default = simple
   followTags = true


### PR DESCRIPTION
See: https://blog.sffc.xyz/post/185195398930/why-you-should-use-git-pull-ff-only

Why: TL;DR the default git pull does a fetch and merge. As I am
transitioning over to a rebase-style workflow, the merge can be a
problem!

How: Updating the configuration in the `git` directory.

Tags: git, rebase