### PR TITLE
Add forked fish pure.

### DIFF
--- a/configstore/update-notifier-gatsby-cli.json
+++ b/configstore/update-notifier-gatsby-cli.json
@@ -1,0 +1,4 @@
+{
+	"optOut": false,
+	"lastUpdateCheck": 1600198996583
+}

--- a/configstore/update-notifier-npm.json
+++ b/configstore/update-notifier-npm.json
@@ -1,0 +1,4 @@
+{
+	"optOut": false,
+	"lastUpdateCheck": 1600198995352
+}

--- a/fish/fishfile
+++ b/fish/fishfile
@@ -1,5 +1,5 @@
 edc/bass
 laughedelic/pisces
-rafaelrinaldi/pure
 jorgebucaran/fishtape
 jorgebucaran/nvm.fish
+alexbielen/pure

--- a/gatsby/config.json
+++ b/gatsby/config.json
@@ -1,0 +1,6 @@
+{
+	"telemetry": {
+		"enabled": true,
+		"machineId": "c9a35a18-92b4-4b06-8b81-8ccc4379a96b"
+	}
+}


### PR DESCRIPTION
Why: The pure library was showing the name of the virtualenv whenever I
was in a virtual env. This fork removes that functionality. Also add some gatsby configuration.

How: I've already forked the repo and made changes. So this just updates
the fish file.

Tags: fish, pure prompt