### PR TITLE
Remove poetry from default nix environment.

### DIFF
--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -32,7 +32,6 @@ let
         pkgs.nix
         pkgs.nodejs-14_x
 	pkgs.python310
-	pkgs.poetry
 	pkgs.ripgrep
         pkgs.rustup
 	pkgs.shellcheck


### PR DESCRIPTION
Removing from the default nix environment because I'll likely source this through shell.nix in Python projects.